### PR TITLE
MPexperiments

### DIFF
--- a/src/xwiimote.c
+++ b/src/xwiimote.c
@@ -448,6 +448,8 @@ static int xwiimote_on(struct xwiimote_dev *dev, DeviceIntPtr device)
 		return BadValue;
 	}
 
+    xwii_iface_mp_start_normalize(dev->iface, 0, 0, 0, true);
+
 	info->fd = xwii_iface_get_fd(dev->iface);
 	if (info->fd >= 0) {
 		dev->handler = xf86AddInputHandler(info->fd, xwiimote_input, dev);

--- a/src/xwiimote.c
+++ b/src/xwiimote.c
@@ -1039,10 +1039,10 @@ static void parse_key(struct xwiimote_dev *dev, const char *key, struct func *ou
 		out->u.btn = 1;
 	} else if (!strcasecmp(key, "right-button")) {
 		out->type = FUNC_BTN;
-		out->u.btn = 2;
+		out->u.btn = 3;
 	} else if (!strcasecmp(key, "middle-button")) {
 		out->type = FUNC_BTN;
-		out->u.btn = 3;
+		out->u.btn = 2;
 	} else {
 		for (i = 0; key2value[i].key; ++i) {
 			if (!strcasecmp(key2value[i].key, key))

--- a/src/xwiimote.c
+++ b/src/xwiimote.c
@@ -475,7 +475,7 @@ static BOOL xwiimote_validate(struct xwiimote_dev *dev)
 	}
 
 	hid = udev_device_get_property_value(p, "HID_ID");
-	if (!hid || strcmp(hid, "0005:0000057E:00000306")) {
+	if (!hid || (strcmp(hid, "0005:0000057E:00000306") && strcmp(hid, "0005:0000057E:00000330"))) {
 		xf86IDrvMsg(dev->info, X_ERROR, "No Wii Remote HID device\n");
 		ret = FALSE;
 		goto err_dev;

--- a/xorg-xwiimote.4
+++ b/xorg-xwiimote.4
@@ -87,6 +87,11 @@ Devices) is used. Also still
 .B highly expreimental
 and should not be used!
 
+.IP "\fBOption \*qMPNormalize\*q \fP\*ON or Int:Int:Int\*q"
+.IP "\fBOption \*qMPCalibrationFactor\*q \fP\*ON or Int\*q"
+If running in MotionSource MotionPlus configuration, MPNormalize can be activated
+via ON or with some initial values in order to start normalization.
+
 .PP
 The following options specify keymaps for the buttons of a Wii Remote. The
 \fIval\fP field of the options must be one of the linux input-key/btn constants.

--- a/xorg-xwiimote.4
+++ b/xorg-xwiimote.4
@@ -76,11 +76,15 @@ want to disable device hot-plug.
 .IP "\fBOption \*qMotionSource\*q \fP\*qsource\*q"
 The Wii Remote can be used as motion input device (like a mouse). This selects
 what kind of motion-emulation should be performed. \fBsource\fP can be one of
-\fBaccelerometer\fP or \fBoff\fP. Default is \fBoff\fP which means no
+\fBaccelerometer\fP, \fBMotionPlus\fP or \fBoff\fP. Default is \fBoff\fP which means no
 motion-emulation is done. \fBaccelerometer\fP means that the accelerometer is
 used to calculate current tilt and use this as absolute pointer input. This is
 still
 .B experimental
+and should not be used!
+\fBMotionPlus\fP means that the gyroscope of MotionPlus extensions (or Gen2.0
+Devices) is used. Also still 
+.B highly expreimental
 and should not be used!
 
 .PP


### PR DESCRIPTION
This branch is now adapted to the latest version of MPcalibration in libxwiimote branch.
With this patchset the wiimote can now be used as gyro-mouse on any machine.

I use KeyB as left-mouse and KeyA as right-mouse with an MPCalibrationFactor of 25 and
MPNormalize of 0:300:700 as startvalues (got them from xwiishow)
