### PR TITLE
configure fails because AUTOMAKE_OPTIONS = subdir-objects is not set

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,6 +24,7 @@
 #
 
 ACLOCAL_AMFLAGS = -I m4
+AUTOMAKE_OPTIONS = subdir-objects
 
 EXTRA_DIST = \
 	README \

--- a/README
+++ b/README
@@ -4,7 +4,7 @@ This package includes an X.Org input driver for Nintendo Wii Remotes. It is
 based on the xwiimote packages available at http://github.com/dvdhrm/xwiimote.
 
 To install this driver use:
-	./configure --prefix=/usr
+	./autogen.sh --prefix=/usr
 	make
 	make install
 


### PR DESCRIPTION
I'm running an up-to-date Arch Linux. When I first run configure, I get this error:

configure: creating ./config.status
config.status: error: cannot find input file: `Makefile.in'

So I tried running autogen.sh, which resulted in:

automake: warnings are treated as errors
Makefile.am:43: warning: source file 'src/@DRIVER_NAME@.c' is in a subdirectory,
Makefile.am:43: but option 'subdir-objects' is disabled
automake: warning: possible forward-incompatibility.
automake: At least a source file is in a subdirectory, but the 'subdir-objects'
automake: automake option hasn't been enabled. For now, the corresponding output
automake: object file(s) will be placed in the top-level directory. However,
automake: this behaviour will change in future Automake versions: they will
automake: unconditionally cause object files to be placed in the same subdirectory
automake: of the corresponding sources.
automake: You are advised to start using 'subdir-objects' option throughout your
automake: project, to avoid future incompatibilities.
autoreconf: automake failed with exit status: 1

I was able to fix this by adding the line:

AUTOMAKE_OPTIONS = subdir-objects

to Makefile.am. I added it right underneath the ACLOCAL_AMFLAGS line.

After that, running autogen.sh did work (but configure did not work if run first).
