### PR TITLE
Update event code file

### DIFF
--- a/xorg-xwiimote.4
+++ b/xorg-xwiimote.4
@@ -180,7 +180,7 @@ non-IR keys.
 The following options specify keymaps for the buttons of a Wii Remote. The
 \fIval\fP field of the options must be one of the linux input-key/btn constants.
 You can find them in
-.B /usr/include/linux/input.h.
+.B /usr/include/linux/input-event-codes.h.
 They start with
 .B KEY_*
 or


### PR DESCRIPTION
Since Linux 4.4, the event codes have moved to a new location. This change points it to that new location.